### PR TITLE
Created SpecUtil to handle common api request config and common assertions

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.*;
 import org.testng.annotations.Test;
 
 import com.api.constant.Role;
+import com.api.utils.SpecUtil;
+
 import static com.api.utils.ConfigManager.*;
 
 import static com.api.utils.AuthTokenProvider.*;
@@ -22,25 +24,19 @@ public class CountAPITest {
 	public void verifyCountAPIResponse() {
 				
 					given()
-						.baseUri(readProperty("BASE_URI"))
-						.header("Authorization",getToken(Role.FD))
-						.log().uri()
-						.log().method()
-						.log().headers()
+						.spec(SpecUtil.requestSpecWithAuth(Role.FD))		
 					.when()
 						.get("dashboard/count")
 					.then()
-						.log().ifValidationFails()
-						.statusCode(200)
-						.time(lessThan(1000L))
+						.spec(SpecUtil.responseSpec_OK())
 						.body("message", equalTo("Success"))
 						.body("data", notNullValue())
 						.body("data.size()",equalTo(3))
 						.body("data.count", everyItem(greaterThanOrEqualTo(0)))
 						.body("data.label", not(blankOrNullString()))
 						.body("data.key", containsInAnyOrder("pending_for_delivery","created_today","pending_fst_assignment"))
-						.body(matchesJsonSchemaInClasspath("response-schema/CountResponseSchema.json"))
-						.extract().response();
+						.body(matchesJsonSchemaInClasspath("response-schema/CountResponseSchema.json"));
+			
 			
 	}
 	
@@ -56,7 +52,6 @@ public class CountAPITest {
 		.when()
 			.get("dashboard/count")
 		.then()
-			.log().all()
-			.statusCode(401);
+			.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 }

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -5,15 +5,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 
-import java.io.IOException;
-
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
-import static com.api.utils.ConfigManager.*;
+import static com.api.utils.SpecUtil.*;
+
+import com.api.utils.SpecUtil;
 import com.model.requests.UserCredentials;
 
-import io.restassured.http.ContentType;
 import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 
@@ -25,24 +23,14 @@ public class LoginAPITest {
 	public void loginAPITest() {
 		
 	Response res=	given()
-		 	.baseUri(readProperty("BASE_URI"))
-		 	.contentType(ContentType.JSON)
-		 	.accept(ContentType.JSON)
-		 	.body(userCredentials)
-		 	.log().uri()
-		 	.log().method()
-		 	.log().body()
-		 	.log().headers()
-		 	
+		 	.spec(requestSpec(userCredentials))		 	
 		.when()
 		 	.post("login")
 		 .then()
-		 	.statusCode(200)
-		 	.time(lessThan(1500L))
+		 	.spec(responseSpec_OK())
 		 	.body("message",equalTo("Success"))
 		 	.body("data.token", notNullValue())
 		 	.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/LoginResponseSchema.json"))
-		 	.log().ifValidationFails()
 		 	.extract().response();
 		 	
 		System.out.println(res.asPrettyString());

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -7,6 +7,10 @@ import java.io.IOException;
 import org.testng.annotations.Test;
 
 import com.api.constant.Role;
+import com.api.utils.SpecUtil;
+
+import groovyjarjarpicocli.CommandLine.Spec;
+
 import static com.api.utils.AuthTokenProvider.*;
 import static com.api.utils.ConfigManager.*;
 
@@ -21,18 +25,12 @@ public class MasterAPITest {
 	public void verifyMasterAPITest(){
 		
 					given()
-						.baseUri(readProperty("BASE_URI"))
-						.header("Authorization",getToken(Role.FD))
-						.contentType("")
-						.log().uri()
-						.log().headers()
-						.log().body()
+						.spec(SpecUtil.requestSpecWithAuth(Role.FD))						
 					.when()
 						.post("master")
 						
 					.then()
-						.statusCode(200)
-						.time(lessThan(1000L))
+						.spec(SpecUtil.responseSpec_OK())
 						.body("message", equalTo("Success"))
 						.body("data", notNullValue())
 						.body("data", hasKey("mst_oem"))
@@ -51,16 +49,10 @@ public class MasterAPITest {
 	@Test
 	public void invalidTokenMasterAPITest() {
 		given()
-		.baseUri(readProperty("BASE_URI"))
-		.header("Authorization","")
-		.contentType("")
-		.log().uri()
-		.log().headers()
-		.log().body()
+		.spec(SpecUtil.requestSpec())		
 	.when()
 		.post("master")
 	.then()
-		.statusCode(401)
-		.log().all();
+		.spec(SpecUtil.responseSpec_TEXT(401));
 	}
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import static com.api.constant.Role.*;
 
 import static com.api.utils.AuthTokenProvider.*;
@@ -22,25 +24,14 @@ public class UserDetailsAPITest {
 	
 	@Test
 	public void userDetailsAPITest() {
-		
-		Header authHeader = new Header("Authorization",getToken(FD));
-		
+				
 		given()
-			.baseUri(readProperty("BASE_URI"))
-			.header(authHeader)
-			.accept(ContentType.JSON)
-			.log().uri()
-			.log().method()
-			.log().body()
-			.log().headers()
+			.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 			.get("userdetails")
 		.then()
-			.statusCode(200)
-			.time(Matchers.lessThan(1500L))
-			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"));
-			
-		
+			.spec(SpecUtil.responseSpec_OK())
+			.body(JsonSchemaValidator.matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"));	
 		
 	}
 }

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,95 @@
+package com.api.utils;
+
+import java.util.concurrent.TimeUnit;
+
+import org.hamcrest.Matchers;
+
+import com.api.constant.Role;
+import com.model.requests.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+
+	public static RequestSpecification requestSpec() {
+		//To take care of common request sections
+		RequestSpecification requestSpecification= new RequestSpecBuilder()
+		 .setBaseUri(ConfigManager.readProperty("BASE_URI"))
+		 .setContentType(ContentType.JSON)
+		 .setAccept(ContentType.JSON)
+		 .log(LogDetail.URI)
+		 .log(LogDetail.METHOD)
+		 .log(LogDetail.HEADERS)
+		 .log(LogDetail.BODY)
+		 .build();
+		return requestSpecification;
+
+	}
+	
+	//POST,PUT,PATCH 
+	public static RequestSpecification requestSpec(Object payload) {
+		//To take care of common request sections
+		RequestSpecification requestSpecification= new RequestSpecBuilder()
+		 .setBaseUri(ConfigManager.readProperty("BASE_URI"))
+		 .setContentType(ContentType.JSON)
+		 .setAccept(ContentType.JSON)
+		 .setBody(payload)
+		 .log(LogDetail.URI)
+		 .log(LogDetail.METHOD)
+		 .log(LogDetail.HEADERS)
+		 .log(LogDetail.BODY)
+		 .build();
+		return requestSpecification;
+
+	}
+	
+	public static RequestSpecification requestSpecWithAuth(Role role) {
+		//To take care of common request sections
+		RequestSpecification requestSpecification= new RequestSpecBuilder()
+		 .setBaseUri(ConfigManager.readProperty("BASE_URI"))
+		 .setContentType(ContentType.JSON)
+		 .setAccept(ContentType.JSON)
+		 .addHeader("Authorization", AuthTokenProvider.getToken(role))
+		 .log(LogDetail.URI)
+		 .log(LogDetail.METHOD)
+		 .log(LogDetail.HEADERS)
+		 .log(LogDetail.BODY)
+		 .build();
+		return requestSpecification;
+
+	}
+	
+	public static ResponseSpecification responseSpec_OK() {
+		ResponseSpecification responseSpecification= new ResponseSpecBuilder()
+		.expectStatusCode(200)
+		.expectContentType(ContentType.JSON)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();	
+		return responseSpecification;
+	}
+	
+	public static ResponseSpecification responseSpec_JSON(int statusCode) {
+		ResponseSpecification responseSpecification= new ResponseSpecBuilder()
+		.expectStatusCode(200)
+		.expectContentType(ContentType.JSON)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();	
+		return responseSpecification;
+	}
+	
+	public static ResponseSpecification responseSpec_TEXT(int statusCode) {
+		ResponseSpecification responseSpecification= new ResponseSpecBuilder()
+		.expectStatusCode(statusCode)
+		.expectResponseTime(Matchers.lessThan(1000L))
+		.log(LogDetail.ALL)
+		.build();	
+		return responseSpecification;
+	}
+}


### PR DESCRIPTION
SpecUtil is consisting of common RequestSpecBuilder and ResponseSpecBuilder. These util methods has reduced the boiler plate code in our api tests and also reduced the number of lines. Making test code smaller and maintainable.